### PR TITLE
fix: replace nested `button` with `span` in MultiSelectChips

### DIFF
--- a/assets/src/components/MultiSelectChips.js
+++ b/assets/src/components/MultiSelectChips.js
@@ -93,14 +93,25 @@ function MultiSelectChips( {
 							return (
 								<span key={ itemValue } className="msc-chip">
 									<span className="msc-chip-label">{ itemLabel }</span>
-									<button
-										type="button"
+									<span
+										role="button"
+										tabIndex={ disabled ? -1 : 0 }
 										className="msc-chip-close"
 										onClick={ handleRemove }
+										onKeyDown={ ( e ) => {
+											if ( disabled ) {
+												return;
+											}
+											if ( e.key === 'Enter' || e.key === ' ' ) {
+												e.preventDefault();
+												handleRemove( e );
+											}
+										} }
 										aria-label={ `Remove ${ itemLabel }` }
+										aria-disabled={ disabled }
 									>
-										<Icon icon={ closeSmall } aria-disabled={ disabled } />
-									</button>
+										<Icon icon={ closeSmall } aria-hidden={ false } aria-disabled={ disabled } />
+									</span>
 								</span>
 							);
 						} )


### PR DESCRIPTION
## Description

<!-- Very brief idea on what this PR does? No technical details. -->

Fixes an error in our `MultiSelectChips` component, where we have a `<button>` nested in a `<button>` tab causing console errors:



## Technical Details

<!-- Any technical details that should be explained or mentioned to the reviewers. -->

## Checklist

<!--
If the ticket you worked on had any checklist, include that here and mark items that are covered in this PR. Else, create a checklist of all the items this PR covers.

Example:
- [ ] Fix incorrect meta key value for the Contact block.
- [ ] Fix footer button alignment issue.
-->

## Screenshots

<!-- Add screenshots or screen recordings if applicable and required. -->

### Before

<img width="1880" height="1063" alt="image" src="https://github.com/user-attachments/assets/521513d6-478e-45e0-bcd8-114502a7041e" />


### After

<img width="1915" height="816" alt="image" src="https://github.com/user-attachments/assets/ad6bcc68-40e1-4e3e-92ed-41086d12a970" />


## To-do

<!-- Mention anything that needs to be done after this PR as a follow-up or if anything is left uncovered. -->

## Fixes/Covers issue

<!-- Add the issue number which the PR is intended to be for. -->
Fixes #

<!-- After you're done creating the PR, assign the PR to yourself and assign reviewers for the PR. If unsure about whom to ask for a review, leave blank and ping on the project-specific channel. -->
