### PR TITLE
fix: cleanup uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -160,7 +160,7 @@ function delete_shared_site_indices( $client ): void {
  * @param string                              $index_name Index name to delete.
  * @return void
  */
-function delete_algolia_index( $client, $index_name ) {
+function delete_algolia_index( $client, $index_name ): void {
 	if ( empty( $index_name ) ) {
 		return;
 	}


### PR DESCRIPTION
## Description

<!-- Very brief idea on what this PR does? No technical details. -->

This PR cleanups `uninstall.php` to support multisite and reduce duplication/redundancy and edge-cases.


> [!IMPORTANT]
> This PR is based on #33 which should be merged first.

## Technical Details

<!-- Any technical details that should be explained or mentioned to the reviewers. -->

1. The functions are namespaced instead of the `function_exists()` spaghetti and redundant prefixes.
2. The options/transients weren't audited, just moved into a (reusable) function.
3. Class-specific autoloading is removed in favor of relying solely on our autoloader. The algolia client lives in composer anyway, and our singleton pattern means other deps will leak in the future w.o explicit tests)
4. Multisite uninstall wraps the single-site uninstall across all sites.

