### PR TITLE
tests: backfill Jest tests

### DIFF
--- a/__mocks__/@wordpress/api-fetch.ts
+++ b/__mocks__/@wordpress/api-fetch.ts
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import type { ApiFetch } from '@wordpress/api-fetch';
+
+const apiFetch = jest.fn() as jest.Mock & ApiFetch;
+
+apiFetch.use = jest.fn();
+apiFetch.createNonceMiddleware = jest.fn( () => {
+	const middleware = jest.fn();
+	( middleware as jest.Mock & { nonce: string } ).nonce = '';
+	return middleware as jest.Mock & { nonce: string };
+} );
+
+export default apiFetch;

--- a/assets/src/admin/onboarding/index.tsx
+++ b/assets/src/admin/onboarding/index.tsx
@@ -6,19 +6,7 @@ import { createRoot } from 'react-dom/client';
 /**
  * Internal dependencies
  */
-import OnboardingScreen, { type SiteType } from './page';
-
-interface OneSearchOnboarding {
-	nonce: string;
-	site_type: SiteType | '';
-	setup_url: string;
-}
-
-declare global {
-	interface Window {
-		OneSearchOnboarding: OneSearchOnboarding;
-	}
-}
+import OnboardingScreen from './page';
 
 // Render to the target element.
 const target = document.getElementById( 'onesearch-site-selection-modal' );

--- a/assets/src/admin/onboarding/page.tsx
+++ b/assets/src/admin/onboarding/page.tsx
@@ -17,10 +17,16 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 
-const BRAND_SITE = 'brand-site';
-const GOVERNING_SITE = 'governing-site';
+/**
+ * Internal dependencies
+ */
+import type { SiteType } from '../../types/global';
 
-export type SiteType = typeof BRAND_SITE | typeof GOVERNING_SITE;
+// Re-export for backward compatibility
+export type { SiteType } from '../../types/global';
+
+const BRAND_SITE = 'brand-site' as const;
+const GOVERNING_SITE = 'governing-site' as const;
 
 interface NoticeState {
 	type: 'success' | 'error' | 'warning' | 'info';
@@ -43,8 +49,8 @@ const SiteTypeSelector = ( {
 	value,
 	setSiteType,
 }: {
-	value: SiteType | '';
-	setSiteType: ( v: SiteType | '' ) => void;
+	value: SiteType;
+	setSiteType: ( v: SiteType ) => void;
 } ) => (
 	<SelectControl
 		label={ __( 'Site Type', 'onesearch' ) }
@@ -53,9 +59,11 @@ const SiteTypeSelector = ( {
 			"Choose your site's primary purpose. This setting cannot be changed later and affects available features and configurations.",
 			'onesearch'
 		) }
-		onChange={ ( v: SiteType | '' ) => {
+		onChange={ ( v: SiteType ) => {
 			setSiteType( v );
 		} }
+		__nextHasNoMarginBottom
+		__next40pxDefaultSize
 		options={ [
 			{ label: __( 'Select…', 'onesearch' ), value: '' },
 			{ label: __( 'Brand Site', 'onesearch' ), value: BRAND_SITE },
@@ -68,7 +76,7 @@ const SiteTypeSelector = ( {
 );
 
 const OnboardingScreen = () => {
-	const [ siteType, setSiteType ] = useState< SiteType | '' >(
+	const [ siteType, setSiteType ] = useState< SiteType >(
 		initialSiteType || ''
 	);
 	const [ notice, setNotice ] = useState< NoticeState | null >( null );
@@ -91,7 +99,7 @@ const OnboardingScreen = () => {
 			} );
 	}, [] ); // for initial component mount
 
-	const handleSiteTypeChange = async ( value: SiteType | '' ) => {
+	const handleSiteTypeChange = async ( value: SiteType ) => {
 		// Optimistically set site type.
 		setSiteType( value );
 		setIsSaving( true );

--- a/assets/src/admin/settings/index.tsx
+++ b/assets/src/admin/settings/index.tsx
@@ -8,27 +8,6 @@ import { createRoot } from 'react-dom/client';
  */
 import SettingsPage from './page';
 
-export type SiteType = 'governing-site' | 'brand-site' | '';
-
-interface OneSearchSettingsType {
-	restUrl: string;
-	restNonce: string;
-	api_key: string;
-	settingsLink: string;
-	siteType: SiteType;
-
-	// @todo legacy - to be removed later
-	restNamespace?: string;
-	nonce?: string;
-	currentSiteUrl?: string;
-}
-
-declare global {
-	interface Window {
-		OneSearchSettings: OneSearchSettingsType;
-	}
-}
-
 // Render to Gutenberg admin page with ID: onesearch-settings-page
 const target = document.getElementById( 'onesearch-settings-page' );
 if ( target ) {

--- a/assets/src/admin/settings/page.tsx
+++ b/assets/src/admin/settings/page.tsx
@@ -38,7 +38,7 @@ export const defaultBrandSite: BrandSite = {
 
 export type EditingIndex = number | null;
 
-const NONCE = window.OneSearchSettings.restNonce;
+const NONCE = window.OneSearchSettings.nonce;
 const SITE_TYPE = ( window.OneSearchSettings.siteType as SiteType ) || '';
 const SHARED_SITES_ENDPOINT = '/onesearch/v1/shared-sites';
 

--- a/assets/src/js/utils.ts
+++ b/assets/src/js/utils.ts
@@ -5,15 +5,6 @@
  *
  * @return {boolean} True if the string is a valid URL, false otherwise.
  */
-const isURL = ( str: string ): boolean => {
-	try {
-		new URL( str );
-		return true;
-	} catch {
-		return false;
-	}
-};
-
 /**
  * Validates if a given string is a valid URL.
  *
@@ -23,8 +14,8 @@ const isURL = ( str: string ): boolean => {
  */
 export const isValidUrl = ( url: string ): boolean => {
 	try {
-		const parsedUrl = new URL( url );
-		return isURL( parsedUrl.href );
+		new URL( url );
+		return true;
 	} catch {
 		return false;
 	}

--- a/assets/src/types/global.d.ts
+++ b/assets/src/types/global.d.ts
@@ -1,0 +1,40 @@
+/**
+ * Global type declarations for OneSearch.
+ *
+ * These types describe the window globals injected by WordPress PHP code.
+ */
+
+export type SiteType = 'governing-site' | 'brand-site' | '';
+
+export interface OneSearchSharedSite {
+	name: string;
+	url: string;
+	api_key?: string;
+}
+
+export interface OneSearchSettings {
+	restUrl: string;
+	restNonce: string;
+	api_key: string;
+	settingsLink: string;
+	siteType: SiteType;
+	sharedSites?: OneSearchSharedSite[];
+
+	// @todo legacy - to be removed later
+	restNamespace?: string;
+	nonce?: string;
+	currentSiteUrl?: string;
+}
+
+export interface OneSearchOnboarding {
+	nonce: string;
+	site_type: SiteType | '';
+	setup_url: string;
+}
+
+declare global {
+	interface Window {
+		OneSearchSettings: OneSearchSettings;
+		OneSearchOnboarding: OneSearchOnboarding;
+	}
+}

--- a/assets/src/types/global.d.ts
+++ b/assets/src/types/global.d.ts
@@ -14,16 +14,14 @@ export interface OneSearchSharedSite {
 
 export interface OneSearchSettings {
 	restUrl: string;
-	restNonce: string;
+	nonce: string;
 	api_key: string;
-	settingsLink: string;
+	setupUrl: string;
 	siteType: SiteType;
 	sharedSites?: OneSearchSharedSite[];
-
-	// @todo legacy - to be removed later
-	restNamespace?: string;
-	nonce?: string;
-	currentSiteUrl?: string;
+	restNamespace: string;
+	currentSiteUrl: string;
+	indexableEntities?: Record< string, string[] >;
 }
 
 export interface OneSearchOnboarding {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
 		"prepare": "lefthook install",
 		"start:js": "wp-scripts start --experimental-modules --blocks-manifest",
 		"test:e2e": "wp-scripts test-playwright",
-		"test:js": "wp-scripts test-unit-js --passWithNoTests",
+		"test:js": "wp-scripts test-unit-js",
 		"test:js:watch": "wp-scripts test-unit-js --watch",
-		"test:js:coverage": "wp-scripts test-unit-js --coverage --passWithNoTests",
+		"test:js:coverage": "wp-scripts test-unit-js --coverage",
 		"test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/onesearch vendor/bin/phpunit -c phpunit.xml.dist",
 		"wp-env": "wp-env",
 		"wp-env:cli": "wp-env run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/"

--- a/tests/js/AlgoliaSettings.test.tsx
+++ b/tests/js/AlgoliaSettings.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+import AlgoliaSettings from '@/components/AlgoliaSettings';
+
+const mockedApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+describe( 'AlgoliaSettings', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'loads saved credentials and keeps save disabled until values change', async () => {
+		const setNotice = jest.fn();
+
+		mockedApiFetch.mockImplementation( ( params ) => {
+			if (
+				params &&
+				typeof params === 'object' &&
+				( params as Record< string, unknown > )[ 'path' ] ===
+					'/onesearch/v1/algolia-credentials'
+			) {
+				return Promise.resolve( {
+					app_id: '  app-id  ',
+					write_key: '  write-key  ',
+				} );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		render( <AlgoliaSettings setNotice={ setNotice } /> );
+
+		const appIdInput = await screen.findByRole( 'textbox', {
+			name: /Application ID/i,
+		} );
+		expect( appIdInput ).toHaveValue( 'app-id' );
+
+		expect( screen.getByLabelText( 'Write API Key*' ) ).toHaveValue(
+			'write-key'
+		);
+		expect(
+			screen.getByRole( 'button', { name: /Save Credentials/i } )
+		).toBeDisabled();
+	} );
+
+	it( 'shows an error notice when loading credentials fails', async () => {
+		const setNotice = jest.fn();
+
+		mockedApiFetch.mockImplementation( () =>
+			Promise.reject( new Error( 'failed' ) )
+		);
+
+		render( <AlgoliaSettings setNotice={ setNotice } /> );
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: 'error',
+					message: expect.stringMatching(
+						/Error fetching Algolia credentials/i
+					),
+				} )
+			);
+		} );
+	} );
+
+	it( 'saves changed credentials and reports success', async () => {
+		const setNotice = jest.fn();
+
+		mockedApiFetch.mockImplementation( ( params ) => {
+			if (
+				params &&
+				typeof params === 'object' &&
+				( params as Record< string, unknown > )[ 'method' ] === 'POST'
+			) {
+				return Promise.resolve( { success: true } );
+			}
+			if (
+				params &&
+				typeof params === 'object' &&
+				( params as Record< string, unknown > )[ 'path' ] ===
+					'/onesearch/v1/algolia-credentials'
+			) {
+				return Promise.resolve( {
+					app_id: 'app-id',
+					write_key: 'write-key',
+				} );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		render( <AlgoliaSettings setNotice={ setNotice } /> );
+
+		const appIdInput = await screen.findByRole( 'textbox', {
+			name: /Application ID/i,
+		} );
+		fireEvent.change( appIdInput, { target: { value: 'updated-app' } } );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: /Save Credentials/i } )
+		);
+
+		await waitFor( () => {
+			expect( mockedApiFetch ).toHaveBeenLastCalledWith(
+				expect.objectContaining( {
+					path: '/onesearch/v1/algolia-credentials',
+					method: 'POST',
+					data: expect.objectContaining( {
+						app_id: 'updated-app',
+						write_key: 'write-key',
+					} ),
+				} )
+			);
+		} );
+
+		expect( setNotice ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'success',
+				message: expect.stringMatching(
+					/Algolia credentials saved successfully/i
+				),
+			} )
+		);
+	} );
+
+	it( 'reports an error when saving fails', async () => {
+		const setNotice = jest.fn();
+
+		mockedApiFetch.mockImplementation( ( params ) => {
+			if (
+				params &&
+				typeof params === 'object' &&
+				( params as Record< string, unknown > )[ 'method' ] === 'POST'
+			) {
+				return Promise.reject( new Error( 'save failed' ) );
+			}
+			if (
+				params &&
+				typeof params === 'object' &&
+				( params as Record< string, unknown > )[ 'path' ] ===
+					'/onesearch/v1/algolia-credentials'
+			) {
+				return Promise.resolve( {
+					app_id: 'app-id',
+					write_key: 'write-key',
+				} );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		render( <AlgoliaSettings setNotice={ setNotice } /> );
+
+		// Use getByLabelText for password field (not a textbox role)
+		const writeKeyInput = await screen.findByLabelText( /Write API Key/i );
+		fireEvent.change( writeKeyInput, { target: { value: 'new-key' } } );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: /Save Credentials/i } )
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					type: 'error',
+					message: expect.stringMatching(
+						/Error saving Algolia credentials/i
+					),
+				} )
+			);
+		} );
+	} );
+} );

--- a/tests/js/MultiSelectChips.test.tsx
+++ b/tests/js/MultiSelectChips.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import MultiSelectChips from '@/components/MultiSelectChips';
+
+const options = [
+	{ slug: 'post', label: 'Posts' },
+	{ slug: 'page', label: 'Pages' },
+];
+
+describe( 'MultiSelectChips', () => {
+	it( 'shows a placeholder when nothing is selected', () => {
+		render( <MultiSelectChips label="Entities" options={ options } /> );
+
+		expect( screen.getByText( 'Select…' ) ).toBeInTheDocument();
+	} );
+
+	it( 'opens the menu and reports selected values', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<MultiSelectChips
+				label="Entities"
+				options={ options }
+				onChange={ onChange }
+				valueField="slug"
+				labelField="label"
+			/>
+		);
+
+		await act( async () => {
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'Select…' } )
+			);
+		} );
+
+		await act( async () => {
+			fireEvent.click( screen.getByLabelText( 'Posts' ) );
+		} );
+
+		expect( onChange ).toHaveBeenCalledWith( [ 'post' ] );
+	} );
+
+	it( 'renders selected chips and lets users remove them', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<MultiSelectChips
+				label="Entities"
+				options={ options }
+				value={ [ 'post', 'page' ] }
+				onChange={ onChange }
+				valueField="slug"
+				labelField="label"
+			/>
+		);
+
+		expect( screen.getByText( 'Posts' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Pages' ) ).toBeInTheDocument();
+
+		await act( async () => {
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'Remove Posts' } )
+			);
+		} );
+
+		expect( onChange ).toHaveBeenCalledWith( [ 'page' ] );
+	} );
+
+	it( 'supports keyboard removal for selected chips', async () => {
+		const onChange = jest.fn();
+
+		render(
+			<MultiSelectChips
+				label="Entities"
+				options={ options }
+				value={ [ 'page' ] }
+				onChange={ onChange }
+				valueField="slug"
+				labelField="label"
+			/>
+		);
+
+		await act( async () => {
+			fireEvent.keyDown(
+				screen.getByRole( 'button', { name: 'Remove Pages' } ),
+				{
+					key: 'Enter',
+				}
+			);
+		} );
+
+		expect( onChange ).toHaveBeenCalledWith( [] );
+	} );
+
+	it( 'closes the menu and blocks changes when disabled', async () => {
+		const onChange = jest.fn();
+		const { rerender } = render(
+			<MultiSelectChips
+				label="Entities"
+				options={ options }
+				onChange={ onChange }
+				valueField="slug"
+				labelField="label"
+			/>
+		);
+
+		await act( async () => {
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'Select…' } )
+			);
+		} );
+		expect( screen.getByRole( 'listbox' ) ).toBeInTheDocument();
+
+		rerender(
+			<MultiSelectChips
+				label="Entities"
+				options={ options }
+				onChange={ onChange }
+				valueField="slug"
+				labelField="label"
+				disabled
+			/>
+		);
+
+		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		await act( async () => {
+			fireEvent.click(
+				screen.getByRole( 'button', { name: 'Select…' } )
+			);
+		} );
+		expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/js/OnboardingScreen.test.tsx
+++ b/tests/js/OnboardingScreen.test.tsx
@@ -12,6 +12,8 @@ import OnboardingScreen from '@/admin/onboarding/page';
 const mockedApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
 
 describe( 'OnboardingScreen', () => {
+	let consoleWarnSpy: jest.SpyInstance;
+
 	beforeEach( () => {
 		mockedApiFetch.mockReset();
 		window.OneSearchOnboarding = {
@@ -19,12 +21,17 @@ describe( 'OnboardingScreen', () => {
 			site_type: '',
 			setup_url: '',
 		};
+		// Suppress WordPress component deprecation warnings (outside our control)
+		consoleWarnSpy = jest
+			.spyOn( console, 'warn' )
+			.mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		consoleWarnSpy.mockRestore();
 	} );
 
 	it( 'loads the current site type from settings', async () => {
-		// Suppress WordPress component deprecation warnings (outside our control)
-		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
-
 		mockedApiFetch.mockResolvedValueOnce( {
 			onesearch_site_type: 'brand-site',
 		} );
@@ -39,9 +46,6 @@ describe( 'OnboardingScreen', () => {
 	} );
 
 	it( 'shows an error notice when loading fails', async () => {
-		// Suppress WordPress component deprecation warnings (outside our control)
-		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
-
 		mockedApiFetch.mockRejectedValueOnce( new Error( 'load failed' ) );
 
 		render( <OnboardingScreen /> );
@@ -53,9 +57,6 @@ describe( 'OnboardingScreen', () => {
 	} );
 
 	it( 'saves the chosen site type', async () => {
-		// Suppress WordPress component deprecation warnings (outside our control)
-		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
-
 		mockedApiFetch.mockResolvedValueOnce( {} ).mockResolvedValueOnce( {
 			onesearch_site_type: 'governing-site',
 		} );
@@ -79,9 +80,6 @@ describe( 'OnboardingScreen', () => {
 	} );
 
 	it( 'shows an error notice when saving fails', async () => {
-		// Suppress WordPress component deprecation warnings (outside our control)
-		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
-
 		mockedApiFetch
 			.mockResolvedValueOnce( {} )
 			.mockRejectedValueOnce( new Error( 'save failed' ) );

--- a/tests/js/OnboardingScreen.test.tsx
+++ b/tests/js/OnboardingScreen.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+import OnboardingScreen from '@/admin/onboarding/page';
+
+const mockedApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+describe( 'OnboardingScreen', () => {
+	beforeEach( () => {
+		mockedApiFetch.mockReset();
+		window.OneSearchOnboarding = {
+			nonce: 'onboarding-nonce',
+			site_type: '',
+			setup_url: '',
+		};
+	} );
+
+	it( 'loads the current site type from settings', async () => {
+		// Suppress WordPress component deprecation warnings (outside our control)
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+		mockedApiFetch.mockResolvedValueOnce( {
+			onesearch_site_type: 'brand-site',
+		} );
+
+		render( <OnboardingScreen /> );
+
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'Site Type' ) ).toHaveValue(
+				'brand-site'
+			);
+		} );
+	} );
+
+	it( 'shows an error notice when loading fails', async () => {
+		// Suppress WordPress component deprecation warnings (outside our control)
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+		mockedApiFetch.mockRejectedValueOnce( new Error( 'load failed' ) );
+
+		render( <OnboardingScreen /> );
+
+		// WordPress renders notices in both accessibility region and visible content
+		expect(
+			await screen.findAllByText( 'Error fetching site type.' )
+		).toHaveLength( 2 );
+	} );
+
+	it( 'saves the chosen site type', async () => {
+		// Suppress WordPress component deprecation warnings (outside our control)
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+		mockedApiFetch.mockResolvedValueOnce( {} ).mockResolvedValueOnce( {
+			onesearch_site_type: 'governing-site',
+		} );
+
+		render( <OnboardingScreen /> );
+
+		fireEvent.change( await screen.findByLabelText( 'Site Type' ), {
+			target: { value: 'governing-site' },
+		} );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Select Current Site Type' } )
+		);
+
+		await waitFor( () => {
+			expect( mockedApiFetch ).toHaveBeenLastCalledWith( {
+				path: '/wp/v2/settings',
+				method: 'POST',
+				data: { onesearch_site_type: 'governing-site' },
+			} );
+		} );
+	} );
+
+	it( 'shows an error notice when saving fails', async () => {
+		// Suppress WordPress component deprecation warnings (outside our control)
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+		mockedApiFetch
+			.mockResolvedValueOnce( {} )
+			.mockRejectedValueOnce( new Error( 'save failed' ) );
+
+		render( <OnboardingScreen /> );
+
+		fireEvent.change( await screen.findByLabelText( 'Site Type' ), {
+			target: { value: 'brand-site' },
+		} );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Select Current Site Type' } )
+		);
+
+		// WordPress renders notices in both accessibility region and visible content
+		expect(
+			await screen.findAllByText( 'Error setting site type.' )
+		).toHaveLength( 2 );
+	} );
+} );

--- a/tests/js/SettingsPage.test.tsx
+++ b/tests/js/SettingsPage.test.tsx
@@ -1,0 +1,336 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+// Mock child components to isolate SettingsPage behavior
+jest.mock( '@/components/SiteTable', () => ( {
+	__esModule: true,
+	default: ( {
+		sites,
+		onEdit,
+		onDelete,
+		setFormData,
+		setShowModal,
+	}: {
+		sites: Array< { name: string; url: string; api_key: string } >;
+		onEdit: ( index: number ) => void;
+		onDelete: ( index: number | null ) => void;
+		setFormData: ( data: {
+			name: string;
+			url: string;
+			api_key: string;
+		} ) => void;
+		setShowModal: ( show: boolean ) => void;
+	} ) => (
+		<div data-testid="site-table">
+			<span data-testid="site-count">{ sites.length }</span>
+			<button
+				type="button"
+				onClick={ () => {
+					onEdit( 0 );
+					setFormData( {
+						name: 'Edited Brand Site',
+						url: 'https://edited.example.com/',
+						api_key: 'edited-key',
+					} );
+				} }
+			>
+				Edit Site
+			</button>
+			<button type="button" onClick={ () => setShowModal( true ) }>
+				Open Modal
+			</button>
+			<button type="button" onClick={ () => onDelete( 0 ) }>
+				Delete Site
+			</button>
+		</div>
+	),
+} ) );
+
+jest.mock( '@/components/SiteModal', () => ( {
+	__esModule: true,
+	default: ( {
+		onSubmit,
+		onClose,
+	}: {
+		onSubmit: () => Promise< boolean >;
+		onClose: () => void;
+	} ) => (
+		<div data-testid="site-modal">
+			<button type="button" onClick={ () => void onSubmit() }>
+				Submit Modal
+			</button>
+			<button type="button" onClick={ onClose }>
+				Close Modal
+			</button>
+		</div>
+	),
+} ) );
+
+jest.mock( '@/components/SiteSettings', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="site-settings">Brand Site Settings</div>,
+} ) );
+
+jest.mock( '@/components/AlgoliaSettings', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="algolia-settings">Algolia Settings</div>,
+} ) );
+
+import SettingsPage from '@/admin/settings/page';
+
+const mockedApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+describe( 'SettingsPage', () => {
+	beforeEach( () => {
+		mockedApiFetch.mockReset();
+		window.OneSearchSettings = {
+			...window.OneSearchSettings,
+			siteType: 'governing-site',
+		};
+		document.body.className = '';
+	} );
+
+	it( 'loads shared sites and renders the page structure', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {
+			shared_sites: [
+				{
+					name: 'Brand Site',
+					url: 'https://brand.example.com/',
+					api_key: 'key',
+				},
+			],
+		} );
+
+		render( <SettingsPage /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'site-count' ) ).toHaveTextContent(
+				'1'
+			);
+		} );
+
+		expect( screen.getByTestId( 'algolia-settings' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows an error notice when initial data load fails', async () => {
+		mockedApiFetch.mockRejectedValueOnce( new Error( 'load failed' ) );
+
+		render( <SettingsPage /> );
+
+		// Snackbar component renders once (unlike Notice which renders twice for accessibility)
+		const notices = await screen.findAllByText(
+			'Error fetching settings data.'
+		);
+		expect( notices.length ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'saves site changes and shows success feedback', async () => {
+		mockedApiFetch
+			.mockResolvedValueOnce( { shared_sites: [] } )
+			.mockResolvedValueOnce( {
+				shared_sites: [
+					{
+						name: 'Brand Site',
+						url: 'https://brand.example.com/',
+						api_key: 'key',
+					},
+				],
+			} );
+
+		render( <SettingsPage /> );
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Open Modal' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Submit Modal' } )
+		);
+
+		// Snackbar renders in both accessibility region and visible content
+		const notices = await screen.findAllByText(
+			'Brand Site saved successfully.'
+		);
+		expect( notices.length ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'shows an error notice when saving fails', async () => {
+		mockedApiFetch
+			.mockResolvedValueOnce( { shared_sites: [] } )
+			.mockRejectedValueOnce( new Error( 'save failed' ) );
+
+		render( <SettingsPage /> );
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Open Modal' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Submit Modal' } )
+		);
+
+		// Snackbar renders in both accessibility region and visible content
+		const notices = await screen.findAllByText(
+			'Failed to update shared sites'
+		);
+		expect( notices.length ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'shows an error when response lacks shared sites', async () => {
+		mockedApiFetch
+			.mockResolvedValueOnce( {
+				shared_sites: [
+					{
+						name: 'Brand Site',
+						url: 'https://brand.example.com/',
+						api_key: 'key',
+					},
+				],
+			} )
+			.mockResolvedValueOnce( {} );
+
+		render( <SettingsPage /> );
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Open Modal' } )
+		);
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Submit Modal' } )
+		);
+
+		// Snackbar renders in both accessibility region and visible content
+		const notices = await screen.findAllByText(
+			'Failed to update shared sites'
+		);
+		expect( notices.length ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'submits edit changes correctly', async () => {
+		mockedApiFetch
+			.mockResolvedValueOnce( {
+				shared_sites: [
+					{
+						name: 'Brand Site',
+						url: 'https://brand.example.com/',
+						api_key: 'key',
+					},
+				],
+			} )
+			.mockResolvedValueOnce( {
+				shared_sites: [
+					{
+						name: 'Edited Brand Site',
+						url: 'https://edited.example.com/',
+						api_key: 'edited-key',
+					},
+				],
+			} );
+
+		render( <SettingsPage /> );
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Edit Site' } )
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Open Modal' } ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Submit Modal' } )
+		);
+
+		await waitFor( () => {
+			expect( mockedApiFetch ).toHaveBeenLastCalledWith(
+				expect.objectContaining( {
+					method: 'POST',
+					data: {
+						sites_data: [
+							{
+								name: 'Edited Brand Site',
+								url: 'https://edited.example.com/',
+								api_key: 'edited-key',
+							},
+						],
+					},
+				} )
+			);
+		} );
+	} );
+
+	it( 'closes the modal via close action', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {
+			shared_sites: [],
+		} );
+
+		render( <SettingsPage /> );
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Open Modal' } )
+		);
+		expect( screen.getByTestId( 'site-modal' ) ).toBeInTheDocument();
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Close Modal' } )
+		);
+
+		expect( screen.queryByTestId( 'site-modal' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'removes the missing sites body class when governing sites load', async () => {
+		document.body.classList.add( 'onesearch-missing-brand-sites' );
+		mockedApiFetch.mockResolvedValueOnce( {
+			shared_sites: [
+				{
+					name: 'Brand Site',
+					url: 'https://brand.example.com/',
+					api_key: 'key',
+				},
+			],
+		} );
+
+		render( <SettingsPage /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'site-count' ) ).toHaveTextContent(
+				'1'
+			);
+		} );
+
+		expect(
+			document.body.classList.contains( 'onesearch-missing-brand-sites' )
+		).toBe( false );
+	} );
+
+	it( 'removes missing sites class when deleting the last site', async () => {
+		document.body.classList.add( 'onesearch-missing-brand-sites' );
+		mockedApiFetch
+			.mockResolvedValueOnce( {
+				shared_sites: [
+					{
+						name: 'Brand Site',
+						url: 'https://brand.example.com/',
+						api_key: 'key',
+					},
+				],
+			} )
+			.mockResolvedValueOnce( {
+				shared_sites: [
+					{
+						name: 'Remaining Site',
+						url: 'https://remaining.example.com/',
+						api_key: 'other-key',
+					},
+				],
+			} );
+
+		render( <SettingsPage /> );
+
+		fireEvent.click(
+			await screen.findByRole( 'button', { name: 'Delete Site' } )
+		);
+
+		await waitFor( () => {
+			expect(
+				document.body.classList.contains(
+					'onesearch-missing-brand-sites'
+				)
+			).toBe( false );
+		} );
+	} );
+} );

--- a/tests/js/SiteIndexableEntities.test.tsx
+++ b/tests/js/SiteIndexableEntities.test.tsx
@@ -1,0 +1,309 @@
+/**
+ * External dependencies
+ */
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
+
+import SiteIndexableEntities from '@/components/SiteIndexableEntities';
+
+const currentSiteUrl = 'https://governing.example.com/';
+const brandSiteUrl = 'https://brand.example.com/';
+
+const okJson = ( data: unknown ) =>
+	( {
+		ok: true,
+		json: jest.fn().mockResolvedValue( data ),
+	} ) as unknown as Response;
+
+describe( 'SiteIndexableEntities', () => {
+	it( 'loads saved entities and enables reindexing when data exists', async () => {
+		global.fetch = jest.fn().mockResolvedValueOnce(
+			okJson( {
+				indexableEntities: {
+					entities: {
+						[ currentSiteUrl ]: [ 'post' ],
+					},
+				},
+			} )
+		) as typeof fetch;
+
+		render(
+			<SiteIndexableEntities
+				sites={ [] }
+				allPostTypes={ {
+					[ currentSiteUrl ]: [ { slug: 'post', label: 'Posts' } ],
+				} }
+				currentSiteUrl={ currentSiteUrl }
+				setNotice={ jest.fn() }
+				onEntitiesSaved={ jest.fn() }
+				saving={ false }
+				setSaving={ jest.fn() }
+			/>
+		);
+
+		await screen.findByText( 'Select Entities to Index' );
+		await waitFor( () => {
+			expect(
+				screen.getByRole( 'button', { name: 'Re-index' } )
+			).toBeEnabled();
+		} );
+	} );
+
+	it( 'shows a message when a brand site has no selectable entities', async () => {
+		global.fetch = jest.fn().mockResolvedValueOnce(
+			okJson( {
+				indexableEntities: {
+					entities: {},
+				},
+			} )
+		) as typeof fetch;
+
+		render(
+			<SiteIndexableEntities
+				sites={ [
+					{
+						name: 'Brand Site',
+						url: brandSiteUrl,
+						api_key: 'brand-key',
+					},
+				] }
+				allPostTypes={ {
+					[ currentSiteUrl ]: [ { slug: 'post', label: 'Posts' } ],
+				} }
+				currentSiteUrl={ currentSiteUrl }
+				setNotice={ jest.fn() }
+				onEntitiesSaved={ jest.fn() }
+				saving={ false }
+				setSaving={ jest.fn() }
+			/>
+		);
+
+		expect(
+			await screen.findByText(
+				'No entities to select. Please check site configuration'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'saves entities and reindexes after changes', async () => {
+		const setNotice = jest.fn();
+		const onEntitiesSaved = jest.fn();
+		const setSaving = jest.fn();
+
+		global.fetch = jest
+			.fn()
+			.mockResolvedValueOnce(
+				okJson( {
+					indexableEntities: {
+						entities: {},
+					},
+				} )
+			)
+			.mockResolvedValueOnce( okJson( { success: true } ) )
+			.mockResolvedValueOnce(
+				okJson( {
+					success: true,
+					message: 'Reindex complete.',
+				} )
+			) as typeof fetch;
+
+		render(
+			<SiteIndexableEntities
+				sites={ [] }
+				allPostTypes={ {
+					[ currentSiteUrl ]: [ { slug: 'post', label: 'Posts' } ],
+				} }
+				currentSiteUrl={ currentSiteUrl }
+				setNotice={ setNotice }
+				onEntitiesSaved={ onEntitiesSaved }
+				saving={ false }
+				setSaving={ setSaving }
+			/>
+		);
+
+		await screen.findByText( 'Select Entities to Index' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Select entities…' } )
+		);
+		fireEvent.click( screen.getByLabelText( 'Posts' ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save Changes' } )
+		);
+
+		await waitFor( () => {
+			expect( onEntitiesSaved ).toHaveBeenCalled();
+		} );
+
+		expect( setSaving ).toHaveBeenCalledWith( true );
+		expect( setSaving ).toHaveBeenLastCalledWith( false );
+		expect( setNotice ).toHaveBeenCalledWith( {
+			message: 'Reindex complete.',
+			type: 'success',
+		} );
+	} );
+
+	it( 'shows a fetch error when loading entities fails', async () => {
+		const setNotice = jest.fn();
+		global.fetch = jest
+			.fn()
+			.mockRejectedValue( new Error( 'load failed' ) ) as typeof fetch;
+
+		render(
+			<SiteIndexableEntities
+				sites={ [] }
+				allPostTypes={ { [ currentSiteUrl ]: [] } }
+				currentSiteUrl={ currentSiteUrl }
+				setNotice={ setNotice }
+				onEntitiesSaved={ jest.fn() }
+				saving={ false }
+				setSaving={ jest.fn() }
+			/>
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				type: 'error',
+				message: 'Error fetching indexable entities.',
+			} );
+		} );
+	} );
+
+	it( 'shows network error notice when saving entities gets non-ok response', async () => {
+		const setNotice = jest.fn();
+		const setSaving = jest.fn();
+
+		global.fetch = jest
+			.fn()
+			.mockResolvedValueOnce(
+				okJson( {
+					indexableEntities: {
+						entities: {},
+					},
+				} )
+			)
+			.mockResolvedValueOnce( {
+				ok: false,
+				json: jest.fn(),
+			} ) as typeof fetch;
+
+		render(
+			<SiteIndexableEntities
+				sites={ [] }
+				allPostTypes={ {
+					[ currentSiteUrl ]: [ { slug: 'post', label: 'Posts' } ],
+				} }
+				currentSiteUrl={ currentSiteUrl }
+				setNotice={ setNotice }
+				onEntitiesSaved={ jest.fn() }
+				saving={ false }
+				setSaving={ setSaving }
+			/>
+		);
+
+		await screen.findByText( 'Select Entities to Index' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Select entities…' } )
+		);
+		fireEvent.click( screen.getByLabelText( 'Posts' ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save Changes' } )
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				message: 'Network response was not ok.',
+				type: 'error',
+			} );
+		} );
+		expect( setSaving ).toHaveBeenLastCalledWith( false );
+	} );
+
+	it( 'opens and closes re-index modal and handles server errors', async () => {
+		const setNotice = jest.fn();
+
+		global.fetch = jest
+			.fn()
+			.mockResolvedValueOnce(
+				okJson( {
+					indexableEntities: {
+						entities: {
+							[ currentSiteUrl ]: [ 'post' ],
+						},
+					},
+				} )
+			)
+			.mockResolvedValueOnce(
+				okJson( {
+					success: false,
+					data: { status: 500 },
+				} )
+			) as typeof fetch;
+
+		render(
+			<SiteIndexableEntities
+				sites={ [] }
+				allPostTypes={ {
+					[ currentSiteUrl ]: [ { slug: 'post', label: 'Posts' } ],
+				} }
+				currentSiteUrl={ currentSiteUrl }
+				setNotice={ setNotice }
+				onEntitiesSaved={ jest.fn() }
+				saving={ false }
+				setSaving={ jest.fn() }
+			/>
+		);
+
+		await screen.findByText( 'Select Entities to Index' );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Select entities…' } )
+		);
+		fireEvent.click( screen.getByLabelText( 'Posts' ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save Changes' } )
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				message: 'Internal server error.',
+				type: 'error',
+			} );
+		} );
+
+		global.fetch = jest.fn().mockResolvedValueOnce(
+			okJson( {
+				success: false,
+				message: 'failed',
+			} )
+		) as typeof fetch;
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Re-index' } ) );
+
+		expect(
+			await screen.findByText( 'Re-index saved entities' )
+		).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect(
+			screen.queryByText( 'Re-index saved entities' )
+		).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Re-index' } ) );
+		fireEvent.click(
+			within( screen.getByRole( 'dialog' ) ).getByRole( 'button', {
+				name: 'Re-index',
+			} )
+		);
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				message: 'failed',
+				type: 'error',
+			} );
+		} );
+	} );
+} );

--- a/tests/js/SiteModal.test.tsx
+++ b/tests/js/SiteModal.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import SiteModal from '@/components/SiteModal';
+import { defaultBrandSite } from '@/admin/settings/page';
+
+const baseFormData = {
+	...defaultBrandSite,
+	name: 'Brand Site',
+	url: 'https://brand.example.com',
+	api_key: 'secret-key',
+};
+
+function SiteModalHarness( {
+	initialData = baseFormData,
+	editing = false,
+	sites = [],
+	originalData,
+	onSubmit = jest.fn().mockResolvedValue( true ),
+}: {
+	initialData?: typeof defaultBrandSite;
+	editing?: boolean;
+	sites?: Array< typeof defaultBrandSite >;
+	originalData?: typeof defaultBrandSite;
+	onSubmit?: jest.Mock< Promise< boolean >, [] >;
+} ) {
+	const [ formData, setFormData ] = useState( initialData );
+
+	return (
+		<SiteModal
+			formData={ formData }
+			setFormData={ setFormData }
+			onSubmit={ onSubmit }
+			onClose={ jest.fn() }
+			editing={ editing }
+			sites={ sites }
+			originalData={ originalData }
+		/>
+	);
+}
+
+describe( 'SiteModal', () => {
+	it( 'disables submit when editing without changes', () => {
+		render(
+			<SiteModalHarness
+				editing
+				initialData={ baseFormData }
+				originalData={ baseFormData }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'Update Site' } )
+		).toBeDisabled();
+	} );
+
+	it( 'shows validation feedback for invalid input', async () => {
+		render(
+			<SiteModalHarness
+				initialData={ {
+					name: 'A very long site name beyond',
+					url: 'invalid-url',
+					api_key: 'secret-key',
+				} }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add Site' } ) );
+
+		// WordPress renders notices in both accessibility region and visible content
+		expect(
+			await screen.findAllByText(
+				'Site Name must be under 20 characters.'
+			)
+		).toHaveLength( 2 );
+	} );
+
+	it( 'prevents duplicate site urls after a successful health check', async () => {
+		const onSubmit = jest.fn().mockResolvedValue( true );
+		global.fetch = jest.fn().mockResolvedValue( {
+			json: jest.fn().mockResolvedValue( { success: true } ),
+		} ) as typeof fetch;
+
+		render(
+			<SiteModalHarness
+				onSubmit={ onSubmit }
+				sites={ [
+					{
+						name: 'Existing',
+						url: 'https://brand.example.com/',
+						api_key: 'existing-key',
+					},
+				] }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add Site' } ) );
+
+		// WordPress renders notices in both accessibility region and visible content
+		expect(
+			await screen.findAllByText(
+				'Site URL already exists. Please use a different URL.'
+			)
+		).toHaveLength( 2 );
+		expect( onSubmit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows a health check error when the remote site rejects the credentials', async () => {
+		const onSubmit = jest.fn().mockResolvedValue( true );
+		global.fetch = jest.fn().mockResolvedValue( {
+			json: jest.fn().mockResolvedValue( { success: false } ),
+		} ) as typeof fetch;
+
+		render( <SiteModalHarness onSubmit={ onSubmit } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add Site' } ) );
+
+		// WordPress renders notices in both accessibility region and visible content
+		expect(
+			await screen.findAllByText(
+				"Health check failed, please verify API key and make sure there's no governing site connected."
+			)
+		).toHaveLength( 2 );
+		expect( onSubmit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows an error when saving the site fails', async () => {
+		const onSubmit = jest.fn().mockResolvedValue( false );
+		global.fetch = jest.fn().mockResolvedValue( {
+			json: jest.fn().mockResolvedValue( { success: true } ),
+		} ) as typeof fetch;
+
+		render( <SiteModalHarness onSubmit={ onSubmit } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add Site' } ) );
+
+		// WordPress renders notices in both accessibility region and visible content
+		expect(
+			await screen.findAllByText(
+				'An error occurred while saving the site. Please try again.'
+			)
+		).toHaveLength( 2 );
+		expect( onSubmit ).toHaveBeenCalled();
+	} );
+
+	it( 'handles unexpected fetch failures gracefully', async () => {
+		global.fetch = jest
+			.fn()
+			.mockRejectedValue( new Error( 'network failed' ) ) as typeof fetch;
+
+		render( <SiteModalHarness /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add Site' } ) );
+
+		// WordPress renders notices in both accessibility region and visible content
+		expect(
+			await screen.findAllByText(
+				'An unexpected error occurred. Please try again.'
+			)
+		).toHaveLength( 2 );
+	} );
+
+	it( 'submits after a successful health check', async () => {
+		const onSubmit = jest.fn().mockResolvedValue( true );
+		global.fetch = jest.fn().mockResolvedValue( {
+			json: jest.fn().mockResolvedValue( { success: true } ),
+		} ) as typeof fetch;
+
+		render( <SiteModalHarness onSubmit={ onSubmit } /> );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Add Site' } ) );
+
+		await waitFor( () => {
+			expect( global.fetch ).toHaveBeenCalledWith(
+				'https://brand.example.com/wp-json/onesearch/v1/health-check',
+				expect.objectContaining( {
+					method: 'GET',
+					headers: expect.objectContaining( {
+						'X-OneSearch-Token': 'secret-key',
+					} ),
+				} )
+			);
+		} );
+
+		expect( onSubmit ).toHaveBeenCalled();
+		expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/tests/js/SiteSearchSettings.test.tsx
+++ b/tests/js/SiteSearchSettings.test.tsx
@@ -1,0 +1,406 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+import SiteSearchSettings from '@/components/SiteSearchSettings';
+
+const mockedApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+const currentSiteUrl = 'https://governing.example.com/';
+const brandSiteUrl = 'https://brand.example.com/';
+
+const defaultEntities = {
+	[ currentSiteUrl ]: [ 'post' ],
+	[ brandSiteUrl ]: [ 'page' ],
+};
+
+const defaultPostTypes = {
+	[ currentSiteUrl ]: [ { slug: 'post' } ],
+	[ brandSiteUrl ]: [ { slug: 'page' } ],
+};
+
+describe( 'SiteSearchSettings', () => {
+	beforeEach( () => {
+		mockedApiFetch.mockReset();
+		window.OneSearchSettings = {
+			...window.OneSearchSettings,
+			currentSiteUrl,
+		};
+
+		Object.defineProperty( window.OneSearchSettings, 'sharedSites', {
+			value: [ { name: 'Brand Site', url: brandSiteUrl } ],
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	it( 'loads and saves search settings', async () => {
+		const setNotice = jest.fn();
+
+		mockedApiFetch
+			.mockResolvedValueOnce( { onesearch_sites_search_settings: {} } )
+			.mockResolvedValueOnce( {
+				onesearch_sites_search_settings: {
+					[ currentSiteUrl ]: {
+						algolia_enabled: true,
+						searchable_sites: [ currentSiteUrl ],
+					},
+					[ brandSiteUrl ]: {
+						algolia_enabled: true,
+						searchable_sites: [ brandSiteUrl ],
+					},
+				},
+			} )
+			.mockResolvedValueOnce( {
+				onesearch_sites_search_settings: {
+					[ currentSiteUrl ]: {
+						algolia_enabled: true,
+						searchable_sites: [ currentSiteUrl ],
+					},
+					[ brandSiteUrl ]: {
+						algolia_enabled: true,
+						searchable_sites: [ brandSiteUrl ],
+					},
+				},
+			} );
+
+		render(
+			<SiteSearchSettings
+				indexableEntities={ defaultEntities }
+				allPostTypes={ defaultPostTypes }
+				setNotice={ setNotice }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await screen.findByText( 'Site Search Configuration' );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Enable All' } ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save Settings' } )
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				type: 'success',
+				message: 'Search settings saved successfully.',
+			} );
+		} );
+	} );
+
+	it( 'warns when enabling sites with no indexable entities', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {
+			onesearch_sites_search_settings: {},
+		} );
+
+		render(
+			<SiteSearchSettings
+				indexableEntities={ {
+					[ currentSiteUrl ]: [ 'post' ],
+					[ brandSiteUrl ]: [],
+				} }
+				allPostTypes={ defaultPostTypes }
+				setNotice={ jest.fn() }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await screen.findByText( 'Site Search Configuration' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Enable All' } ) );
+
+		expect(
+			await screen.findAllByText(
+				'Some sites were skipped because they have no content types selected for indexing. Please configure indexable entities for these sites first.'
+			)
+		).toHaveLength( 2 );
+	} );
+
+	it( 'auto-disables sites when entities are removed', async () => {
+		const setNotice = jest.fn();
+
+		mockedApiFetch
+			.mockResolvedValueOnce( {
+				onesearch_sites_search_settings: {
+					[ currentSiteUrl ]: {
+						algolia_enabled: true,
+						searchable_sites: [ currentSiteUrl ],
+					},
+				},
+			} )
+			.mockResolvedValueOnce( {
+				onesearch_sites_search_settings: {
+					[ currentSiteUrl ]: {
+						algolia_enabled: false,
+						searchable_sites: [],
+					},
+				},
+			} )
+			.mockResolvedValueOnce( {
+				onesearch_sites_search_settings: {
+					[ currentSiteUrl ]: {
+						algolia_enabled: false,
+						searchable_sites: [],
+					},
+				},
+			} );
+
+		const { rerender } = render(
+			<SiteSearchSettings
+				indexableEntities={ { [ currentSiteUrl ]: [ 'post' ] } }
+				allPostTypes={ { [ currentSiteUrl ]: [ { slug: 'post' } ] } }
+				setNotice={ setNotice }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await screen.findByText( 'Site Search Configuration' );
+
+		rerender(
+			<SiteSearchSettings
+				indexableEntities={ { [ currentSiteUrl ]: [] } }
+				allPostTypes={ { [ currentSiteUrl ]: [ { slug: 'post' } ] } }
+				setNotice={ setNotice }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				type: 'success',
+				message:
+					'Sites without indexable entities have been automatically disabled and saved.',
+			} );
+		} );
+	} );
+
+	it( 'shows error when settings fail to load', async () => {
+		const setNotice = jest.fn();
+		mockedApiFetch.mockRejectedValueOnce( new Error( 'load failed' ) );
+
+		render(
+			<SiteSearchSettings
+				indexableEntities={ defaultEntities }
+				allPostTypes={ defaultPostTypes }
+				setNotice={ setNotice }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				type: 'error',
+				message: 'Failed to load search settings.',
+			} );
+		} );
+	} );
+
+	it( 'shows error when settings fail to save', async () => {
+		const setNotice = jest.fn();
+
+		mockedApiFetch
+			.mockResolvedValueOnce( { onesearch_sites_search_settings: {} } )
+			.mockRejectedValueOnce( new Error( 'save failed' ) )
+			.mockResolvedValueOnce( { onesearch_sites_search_settings: {} } );
+
+		render(
+			<SiteSearchSettings
+				indexableEntities={ defaultEntities }
+				allPostTypes={ defaultPostTypes }
+				setNotice={ setNotice }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await screen.findByText( 'Site Search Configuration' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Enable All' } ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save Settings' } )
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				type: 'error',
+				message: 'Failed to save search settings.',
+			} );
+		} );
+	} );
+
+	it( 'disables all sites', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {
+			onesearch_sites_search_settings: {
+				[ currentSiteUrl ]: {
+					algolia_enabled: true,
+					searchable_sites: [ currentSiteUrl ],
+				},
+				[ brandSiteUrl ]: {
+					algolia_enabled: true,
+					searchable_sites: [ brandSiteUrl ],
+				},
+			},
+		} );
+
+		render(
+			<SiteSearchSettings
+				indexableEntities={ defaultEntities }
+				allPostTypes={ defaultPostTypes }
+				setNotice={ jest.fn() }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await screen.findByText( 'Site Search Configuration' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Disable All' } )
+		);
+
+		expect(
+			screen.getAllByText( 'Using default WordPress search' )
+		).toHaveLength( 2 );
+		expect(
+			screen.getByRole( 'button', { name: 'Save Settings' } )
+		).toBeEnabled();
+	} );
+
+	it( 'disables buttons while entities are saving', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {
+			onesearch_sites_search_settings: {},
+		} );
+
+		render(
+			<SiteSearchSettings
+				indexableEntities={ defaultEntities }
+				allPostTypes={ defaultPostTypes }
+				setNotice={ jest.fn() }
+				isIndexableEntitiesSaving
+			/>
+		);
+
+		await screen.findByText( 'Site Search Configuration' );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Enable All' } )
+		).toBeDisabled();
+		expect(
+			screen.getByRole( 'button', { name: 'Disable All' } )
+		).toBeDisabled();
+		expect(
+			screen.getByRole( 'button', { name: 'Save Settings' } )
+		).toBeDisabled();
+	} );
+
+	it( 'locks current site checkbox in searchable sites list', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {
+			onesearch_sites_search_settings: {
+				[ currentSiteUrl ]: {
+					algolia_enabled: true,
+					searchable_sites: [ currentSiteUrl, brandSiteUrl ],
+				},
+			},
+		} );
+
+		render(
+			<SiteSearchSettings
+				indexableEntities={ defaultEntities }
+				allPostTypes={ defaultPostTypes }
+				setNotice={ jest.fn() }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await screen.findByText( 'Site Search Configuration' );
+
+		const currentSiteCheckbox = screen.getByRole( 'checkbox', {
+			name: /Governing Site.*Current Site - Always Included/,
+		} );
+
+		expect( ( currentSiteCheckbox as HTMLInputElement ).disabled ).toBe(
+			true
+		);
+		expect( ( currentSiteCheckbox as HTMLInputElement ).checked ).toBe(
+			true
+		);
+	} );
+
+	it( 'toggles searchable sites', async () => {
+		const setNotice = jest.fn();
+
+		// 1. Initial load, 2. Save, 3. Reload after save
+		mockedApiFetch
+			.mockResolvedValueOnce( {
+				onesearch_sites_search_settings: {
+					[ currentSiteUrl ]: {
+						algolia_enabled: true,
+						searchable_sites: [ currentSiteUrl ],
+					},
+				},
+			} )
+			.mockResolvedValueOnce( {
+				onesearch_sites_search_settings: {
+					[ currentSiteUrl ]: {
+						algolia_enabled: true,
+						searchable_sites: [ currentSiteUrl, brandSiteUrl ],
+					},
+				},
+			} )
+			.mockResolvedValueOnce( {
+				onesearch_sites_search_settings: {
+					[ currentSiteUrl ]: {
+						algolia_enabled: true,
+						searchable_sites: [ currentSiteUrl, brandSiteUrl ],
+					},
+				},
+			} );
+
+		render(
+			<SiteSearchSettings
+				indexableEntities={ defaultEntities }
+				allPostTypes={ defaultPostTypes }
+				setNotice={ setNotice }
+				isIndexableEntitiesSaving={ false }
+			/>
+		);
+
+		await screen.findByText( 'Site Search Configuration' );
+
+		const brandSiteToggle = screen
+			.getAllByRole( 'checkbox', { name: /Brand Site/ } )
+			.find( ( cb ) => ! ( cb as HTMLInputElement ).disabled );
+
+		expect( brandSiteToggle ).toBeTruthy();
+		expect( ( brandSiteToggle as HTMLInputElement ).checked ).toBe( false );
+
+		fireEvent.click( brandSiteToggle! );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Save Settings' } )
+		);
+
+		await waitFor( () => {
+			expect( setNotice ).toHaveBeenCalledWith( {
+				type: 'success',
+				message: 'Search settings saved successfully.',
+			} );
+		} );
+
+		expect( mockedApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				method: 'POST',
+				data: {
+					onesearch_sites_search_settings: {
+						[ currentSiteUrl ]: {
+							algolia_enabled: true,
+							searchable_sites: expect.arrayContaining( [
+								currentSiteUrl,
+								brandSiteUrl,
+							] ),
+						},
+					},
+				},
+			} )
+		);
+	} );
+} );

--- a/tests/js/SiteSettings.test.tsx
+++ b/tests/js/SiteSettings.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import SiteSettings from '@/components/SiteSettings';
+
+const okJson = ( data: unknown ) =>
+	( {
+		ok: true,
+		json: jest.fn().mockResolvedValue( data ),
+	} ) as unknown as Response;
+
+const siteSettingsFetch = ( handlers: {
+	secretKey?: string;
+	governingSiteUrl?: string;
+	regeneratedKey?: string;
+	deleteOk?: boolean;
+	failSecretKey?: boolean;
+	failGoverningSite?: boolean;
+	failRegenerate?: boolean;
+	failDisconnect?: boolean;
+} ) =>
+	jest.fn( async ( input: RequestInfo | URL, init?: RequestInit ) => {
+		const url = String( input );
+		const method = init?.method ?? 'GET';
+
+		if ( url.includes( '/secret-key' ) && method === 'GET' ) {
+			if ( handlers.failSecretKey ) {
+				return { ok: false } as Response;
+			}
+
+			return okJson( { secret_key: handlers.secretKey ?? '' } );
+		}
+
+		if ( url.includes( '/secret-key' ) && method === 'POST' ) {
+			if ( handlers.failRegenerate ) {
+				return { ok: false } as Response;
+			}
+
+			return okJson( { secret_key: handlers.regeneratedKey ?? '' } );
+		}
+
+		if ( url.includes( '/governing-site?' ) && method === 'GET' ) {
+			if ( handlers.failGoverningSite ) {
+				return { ok: false } as Response;
+			}
+
+			return okJson( {
+				governing_site_url: handlers.governingSiteUrl ?? '',
+			} );
+		}
+
+		if ( url.endsWith( '/governing-site' ) && method === 'DELETE' ) {
+			if ( handlers.failDisconnect ) {
+				return { ok: false } as Response;
+			}
+
+			return {
+				ok: handlers.deleteOk ?? true,
+				json: jest.fn().mockResolvedValue( {} ),
+			} as unknown as Response;
+		}
+
+		return { ok: false } as Response;
+	} );
+
+describe( 'SiteSettings', () => {
+	it( 'loads the api key and governing site details', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+		} );
+
+		render( <SiteSettings /> );
+
+		expect(
+			await screen.findByDisplayValue( 'brand-secret' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByDisplayValue( 'https://governing.example.com/' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows an error when loading the api key fails', async () => {
+		global.fetch = siteSettingsFetch( {
+			failSecretKey: true,
+			governingSiteUrl: '',
+		} );
+
+		render( <SiteSettings /> );
+
+		expect(
+			await screen.findByText(
+				'Failed to fetch API key. Please try again later.',
+				{
+					selector: '.components-notice__content',
+				}
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'copies the api key to the clipboard and shows success feedback', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+		} );
+
+		render( <SiteSettings /> );
+
+		await screen.findByDisplayValue( 'brand-secret' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Copy API Key' } )
+		);
+
+		await waitFor( () => {
+			expect( navigator.clipboard.writeText ).toHaveBeenCalledWith(
+				'brand-secret'
+			);
+		} );
+
+		expect(
+			await screen.findByText( 'API key copied to clipboard.', {
+				selector: '.components-notice__content',
+			} )
+		).toBeInTheDocument();
+	} );
+
+	it( 'regenerates the api key and reports success', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+			regeneratedKey: 'new-secret',
+		} );
+
+		render( <SiteSettings /> );
+
+		await screen.findByDisplayValue( 'brand-secret' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Regenerate API Key' } )
+		);
+
+		// Wait for the API call to complete - that's the important behavior
+		await waitFor( () => {
+			expect( global.fetch ).toHaveBeenCalledWith(
+				expect.stringContaining( '/secret-key' ),
+				expect.objectContaining( { method: 'POST' } )
+			);
+		} );
+	} );
+
+	it( 'disconnects from the governing site after confirmation', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+			deleteOk: true,
+		} );
+
+		render( <SiteSettings /> );
+
+		await screen.findByDisplayValue( 'https://governing.example.com/' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Disconnect Governing Site' } )
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Disconnect' } ) );
+
+		expect(
+			await screen.findByText(
+				'Governing site disconnected successfully.',
+				{
+					selector: '.components-notice__content',
+				}
+			)
+		).toBeInTheDocument();
+		expect( screen.getByDisplayValue( '' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows an error notice when copying the api key fails', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+		} );
+		navigator.clipboard.writeText = jest
+			.fn()
+			.mockRejectedValueOnce( new Error( 'clipboard failed' ) );
+
+		render( <SiteSettings /> );
+
+		await screen.findByDisplayValue( 'brand-secret' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Copy API Key' } )
+		);
+
+		expect(
+			await screen.findByText(
+				'Failed to copy api key. Please try again. Error: clipboard failed',
+				{ selector: '.components-notice__content' }
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows an error notice when disconnecting the governing site fails', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+			failDisconnect: true,
+		} );
+
+		render( <SiteSettings /> );
+
+		await screen.findByDisplayValue( 'https://governing.example.com/' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Disconnect Governing Site' } )
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Disconnect' } ) );
+
+		expect(
+			await screen.findByText(
+				'Failed to disconnect governing site. Please try again later.',
+				{ selector: '.components-notice__content' }
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows an error notice when loading the governing site fails', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			failGoverningSite: true,
+		} );
+
+		render( <SiteSettings /> );
+
+		expect(
+			await screen.findByText(
+				'Failed to fetch governing site. Please try again later.',
+				{ selector: '.components-notice__content' }
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows an error notice when regeneration returns no secret key', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+			regeneratedKey: '',
+		} );
+
+		render( <SiteSettings /> );
+
+		await screen.findByDisplayValue( 'brand-secret' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Regenerate API Key' } )
+		);
+
+		expect(
+			await screen.findByText(
+				'Failed to regenerate API key. Please try again later.',
+				{ selector: '.components-notice__content' }
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows an error notice when regenerating the api key fails', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+			failRegenerate: true,
+		} );
+
+		render( <SiteSettings /> );
+
+		await screen.findByDisplayValue( 'brand-secret' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Regenerate API Key' } )
+		);
+
+		expect(
+			await screen.findByText(
+				'Error regenerating API key. Please try again later.',
+				{ selector: '.components-notice__content' }
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'closes the disconnect modal when cancel is clicked', async () => {
+		global.fetch = siteSettingsFetch( {
+			secretKey: 'brand-secret',
+			governingSiteUrl: 'https://governing.example.com/',
+		} );
+
+		render( <SiteSettings /> );
+
+		await screen.findByDisplayValue( 'https://governing.example.com/' );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Disconnect Governing Site' } )
+		);
+
+		expect(
+			screen.getByText(
+				'Are you sure you want to disconnect from the governing site? This action cannot be undone.'
+			)
+		).toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		await waitFor( () => {
+			expect(
+				screen.queryByText(
+					'Are you sure you want to disconnect from the governing site? This action cannot be undone.'
+				)
+			).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/tests/js/SiteTable.test.tsx
+++ b/tests/js/SiteTable.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import SiteTable from '@/components/SiteTable';
+
+const sites = [
+	{
+		name: 'Brand One',
+		url: 'https://brand-one.example.com/',
+		api_key: '1234567890abcdef',
+	},
+];
+
+describe( 'SiteTable', () => {
+	it( 'renders an empty state when there are no brand sites', () => {
+		render(
+			<SiteTable
+				sites={ [] }
+				onEdit={ jest.fn() }
+				onDelete={ jest.fn() }
+				setFormData={ jest.fn() }
+				setShowModal={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText( 'No Brand Sites found.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'opens the add modal when the add button is clicked', () => {
+		const setShowModal = jest.fn();
+
+		render(
+			<SiteTable
+				sites={ [] }
+				onEdit={ jest.fn() }
+				onDelete={ jest.fn() }
+				setFormData={ jest.fn() }
+				setShowModal={ setShowModal }
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: 'Add Brand Site' } )
+		);
+
+		expect( setShowModal ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'passes the selected site to edit handlers', () => {
+		const onEdit = jest.fn();
+		const setFormData = jest.fn();
+		const setShowModal = jest.fn();
+
+		render(
+			<SiteTable
+				sites={ sites }
+				onEdit={ onEdit }
+				onDelete={ jest.fn() }
+				setFormData={ setFormData }
+				setShowModal={ setShowModal }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Edit' } ) );
+
+		expect( setFormData ).toHaveBeenCalledWith( sites[ 0 ] );
+		expect( onEdit ).toHaveBeenCalledWith( 0 );
+		expect( setShowModal ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'confirms deletion before calling onDelete', () => {
+		const onDelete = jest.fn();
+
+		render(
+			<SiteTable
+				sites={ sites }
+				onEdit={ jest.fn() }
+				onDelete={ onDelete }
+				setFormData={ jest.fn() }
+				setShowModal={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+
+		const dialog = screen.getByRole( 'dialog', {
+			name: 'Delete Brand Site',
+		} );
+		expect(
+			within( dialog ).getByText(
+				'Are you sure you want to delete this Brand Site? This action cannot be undone.'
+			)
+		).toBeInTheDocument();
+
+		fireEvent.click(
+			within( dialog ).getByRole( 'button', { name: 'Delete' } )
+		);
+
+		expect( onDelete ).toHaveBeenCalledWith( 0 );
+	} );
+
+	it( 'lets the user cancel deletion', () => {
+		const onDelete = jest.fn();
+
+		render(
+			<SiteTable
+				sites={ sites }
+				onEdit={ jest.fn() }
+				onDelete={ onDelete }
+				setFormData={ jest.fn() }
+				setShowModal={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( onDelete ).not.toHaveBeenCalled();
+		expect(
+			screen.queryByRole( 'dialog', { name: 'Delete Brand Site' } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -17,12 +17,11 @@ Object.defineProperty( window, 'OneSearchSettings', {
 	value: {
 		restUrl: 'https://example.com/wp-json/',
 		restNamespace: 'onesearch/v1',
-		restNonce: 'rest-nonce',
 		nonce: 'nonce',
 		api_key: 'api-key',
 		currentSiteUrl: 'https://governing.example.com/',
 		siteType: 'governing-site',
-		settingsLink: '/wp-admin/admin.php?page=onesearch',
+		setupUrl: '/wp-admin/admin.php?page=onesearch-settings',
 	},
 	writable: true,
 } );

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -3,6 +3,46 @@
  */
 import '@testing-library/jest-dom';
 
+const fetchMock = jest.fn<
+	ReturnType< typeof fetch >,
+	Parameters< typeof fetch >
+>();
+
+Object.defineProperty( global, 'fetch', {
+	value: fetchMock,
+	writable: true,
+} );
+
+Object.defineProperty( window, 'OneSearchSettings', {
+	value: {
+		restUrl: 'https://example.com/wp-json/',
+		restNamespace: 'onesearch/v1',
+		restNonce: 'rest-nonce',
+		nonce: 'nonce',
+		api_key: 'api-key',
+		currentSiteUrl: 'https://governing.example.com/',
+		siteType: 'governing-site',
+		settingsLink: '/wp-admin/admin.php?page=onesearch',
+	},
+	writable: true,
+} );
+
+Object.defineProperty( window, 'OneSearchOnboarding', {
+	value: {
+		nonce: 'onboarding-nonce',
+		site_type: '',
+		setup_url: '',
+	},
+	writable: true,
+} );
+
+Object.defineProperty( navigator, 'clipboard', {
+	value: {
+		writeText: jest.fn().mockResolvedValue( undefined ),
+	},
+	configurable: true,
+} );
+
 /**
  * Jest test setup for OneSearch.
  *
@@ -11,4 +51,5 @@ import '@testing-library/jest-dom';
 
 beforeEach( () => {
 	jest.clearAllMocks();
+	fetchMock.mockReset();
 } );

--- a/tests/js/tsconfig.json
+++ b/tests/js/tsconfig.json
@@ -2,21 +2,15 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"outDir": "../_output/js",
 		"noEmit": true,
-		"types": [ "jest", "node", "@testing-library/jest-dom" ],
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true
+		"baseUrl": "../../",
+		"types": [ "jest", "node", "@testing-library/jest-dom" ]
 	},
 	"include": [
-		"./**/*.ts",
-		"./**/*.tsx",
-		"../../assets/src/**/__tests__/**/*.ts",
-		"../../assets/src/**/__tests__/**/*.tsx",
-		"../../assets/src/**/*.test.ts",
-		"../../assets/src/**/*.test.tsx",
-		"../../assets/src/**/*.spec.ts",
-		"../../assets/src/**/*.spec.tsx"
+		"./*.ts",
+		"./*.tsx",
+		"../../assets/src/**/*.ts",
+		"../../assets/src/**/*.tsx"
 	],
 	"exclude": [ "../../node_modules", "../../build", "../../vendor" ]
 }

--- a/tests/js/utils.test.ts
+++ b/tests/js/utils.test.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import {
+	API_KEY,
+	API_NAMESPACE,
+	CURRENT_SITE_URL,
+	NONCE,
+	REST_NAMESPACE,
+	isValidUrl,
+	withTrailingSlash,
+} from '@/js/utils';
+
+describe( 'utils', () => {
+	it( 'validates well-formed urls', () => {
+		expect( isValidUrl( 'https://example.com/path' ) ).toBe( true );
+		expect( isValidUrl( 'not-a-url' ) ).toBe( false );
+	} );
+
+	it( 'adds a trailing slash only when needed', () => {
+		expect( withTrailingSlash( '' ) ).toBe( '' );
+		expect( withTrailingSlash( 'https://example.com' ) ).toBe(
+			'https://example.com/'
+		);
+		expect( withTrailingSlash( 'https://example.com/' ) ).toBe(
+			'https://example.com/'
+		);
+	} );
+
+	it( 'reads wordpress settings constants from the global config', () => {
+		expect( API_NAMESPACE ).toBe(
+			'https://example.com/wp-json/onesearch/v1'
+		);
+		expect( API_KEY ).toBe( 'api-key' );
+		expect( NONCE ).toBe( 'nonce' );
+		expect( REST_NAMESPACE ).toBe( 'onesearch/v1' );
+		expect( CURRENT_SITE_URL ).toBe( 'https://governing.example.com/' );
+	} );
+} );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	// Point this to your TS ruleset.
 	"extends": "./tsconfig.base.json",
-
-	// Project-specific config.
 	"compilerOptions": {
 		"noEmit": true,
 		"rootDir": ".",
@@ -11,17 +8,15 @@
 		"outDir": "./build",
 		"paths": {
 			"@/*": [ "./assets/src/*" ]
-		},
-		"typeRoots": [ "./node_modules/@types" ]
+		}
 	},
 	"include": [
+		"**/*.d.ts",
 		"**/*.cjs",
 		"**/*.mjs",
 		"**/*.ts",
 		"**/*.tsx",
-		"**/*.json",
-		"tests/**/*.ts",
-		"tests/**/*.tsx"
+		"**/*.json"
 	],
 	"exclude": [ "**/build/*", "vendor/*", "node_modules/*" ]
 }


### PR DESCRIPTION
## Description

<!-- Very brief idea on what this PR does? No technical details. -->

This PR backfills JS Unit tests.

> [!IMPORTANT]
> This PR is based on #146 which should be merged first.

## Technical Details

<!-- Any technical details that should be explained or mentioned to the reviewers. -->

1. Initial work was created with the following prompts (with oh-my-opencode + glm-5)
   ```bash
   Backfill Jest tests for our plugin. Tests should follow best practices, and provide full coverage.
   - Test behavior and outcomes, not implementation details.
   - Don't mock unnecessarily.
   - Ensure tests pass and that `npm run lint:js`, `npm run lint:js:types` pass.
   - No slop.
   1. Run `npm run test:js:coverage` to see the current coverage report
   2. Choose a file with inadequate test coverage in assets/src, study it, and make a plan to add tests to it.
   3. Implement the tests.
   4. Run `npm run test:js:coverage` and ensure the tests pass and coverage improve.
   5. Run `npm run lint:js && npm run lint:js:types` and fix any issues with the tests. Run `npm run test:js:coverage` to verify your work didnt break anything.
   6. Repeat steps 1-6 until we have full test coverage.
   ulw
   ```
   
   ```bash
   Review the existing Jest tests on this branch and deslopify them. Ensure they follow best practices, test real outcomes and not implementation details, and follow best practices. 
   1. Analyze the files in `tests/js` and audit them for slop.
   2. Make a plan and implement any changes you believe are justified.
   3. Ensure `npm run lint:js`, `npm run lint:js:types` and `npm run lint:js:coverage` all pass.
   ```

2. Then I reviewed file by file, prompting or manually fixing changes. 


## Checklist

<!--
If the ticket you worked on had any checklist, include that here and mark items that are covered in this PR. Else, create a checklist of all the items this PR covers.

Example:
- [ ] Fix incorrect meta key value for the Contact block.
- [ ] Fix footer button alignment issue.
-->

## Screenshots

<!-- Add screenshots or screen recordings if applicable and required. -->

```bash
justl@LevineWork:~/work/sites/wptest/repos/onesearch$ npm run test:js:coverage

> test:js:coverage
> wp-scripts test-unit-js --coverage --passWithNoTests

 PASS   onesearch  tests/js/utils.test.ts
 PASS   onesearch  tests/js/SettingsPage.test.tsx
 PASS   onesearch  tests/js/AlgoliaSettings.test.tsx
 PASS   onesearch  tests/js/OnboardingScreen.test.tsx
 PASS   onesearch  tests/js/SiteTable.test.tsx
 PASS   onesearch  tests/js/MultiSelectChips.test.tsx
 PASS   onesearch  tests/js/SiteModal.test.tsx
 PASS   onesearch  tests/js/SiteSettings.test.tsx
 PASS   onesearch  tests/js/SiteIndexableEntities.test.tsx
 PASS   onesearch  tests/js/SiteSearchSettings.test.tsx
---------------------------|---------|----------|---------|---------|-------------------------------------
File                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                   
---------------------------|---------|----------|---------|---------|-------------------------------------
All files                  |   92.11 |    79.13 |   85.61 |   92.14 |                                     
 admin/onboarding          |   90.32 |    81.25 |      90 |   90.32 |                                     
  page.tsx                 |   90.32 |    81.25 |      90 |   90.32 | 114,121,140                         
 admin/settings            |   90.19 |       80 |    87.5 |      90 |                                     
  page.tsx                 |   90.19 |       80 |    87.5 |      90 | 102,138,144,152,161                 
 components                |   92.21 |    78.66 |   84.74 |   92.27 |                                     
  AlgoliaSettings.tsx      |   93.33 |     87.5 |     100 |   92.85 | 63,99                               
  MultiSelectChips.js      |   91.66 |    67.34 |   88.23 |   91.11 | 50,66,115,145                       
  SiteIndexableEntities.js |   90.66 |    71.42 |   88.88 |   90.54 | 60,107,149,182,193,326-344          
  SiteModal.tsx            |   90.32 |    80.39 |   55.55 |   90.16 | 72,150,224-263                      
  SiteSearchSettings.js    |   90.32 |    80.48 |   84.21 |    90.9 | 141,185-196,217-224,232,399,474,532 
  SiteSettings.tsx         |   96.82 |    95.45 |   73.33 |   96.82 | 195,297                             
  SiteTable.tsx            |     100 |      100 |     100 |     100 |                                     
 js                        |     100 |      100 |     100 |     100 |                                     
  utils.ts                 |     100 |      100 |     100 |     100 |                                     
---------------------------|---------|----------|---------|---------|-------------------------------------

=============================== Coverage summary ===============================
Statements   : 92.11% ( 479/520 )
Branches     : 79.13% ( 292/369 )
Functions    : 85.61% ( 125/146 )
Lines        : 92.14% ( 469/509 )
================================================================================

Test Suites: 10 passed, 10 total
Tests:       63 passed, 63 total
Snapshots:   0 total
Time:        4.913 s, estimated 5 s
Ran all test suites.
```

## To-do

<!-- Mention anything that needs to be done after this PR as a follow-up or if anything is left uncovered. -->

## Fixes/Covers issue

<!-- Add the issue number which the PR is intended to be for. -->
Fixes #

<!-- After you're done creating the PR, assign the PR to yourself and assign reviewers for the PR. If unsure about whom to ask for a review, leave blank and ping on the project-specific channel. -->
