### PR TITLE
ci: fix codecov relative path

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -3,7 +3,7 @@
 
 # Fix path prefixes from Docker container paths to repo-relative paths
 fixes:
-  - '/var/www/html/wp-content/plugins/onesearch'
+  - '/var/www/html/wp-content/plugins/onesearch/::'
 
 coverage:
   status:


### PR DESCRIPTION
## Description

<!-- Very brief idea on what this PR does? No technical details. -->

Fixes the relative path prefix in the codecov config.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22OneSearch%20Demo%22%2C%22description%22%3A%22Cross-site%2C%20brand-aware%20search%20across%20a%20multi-brand%20WordPress%20network%2C%20powered%20by%20Algolia.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22search%22%2C%22multisite%22%2C%22algolia%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fonesearch%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-201-98c7d12ccc3111a75adea2008ced562e07e9f5cb.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->