### PR TITLE
chore: downgrade @wordpress/use-recommended-components to warn

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,7 +44,7 @@ export default [
 			'@wordpress/data-no-store-string-literals': 'error',
 			'@wordpress/wp-global-usage': 'error',
 			'@wordpress/react-no-unsafe-timeout': 'error',
-			'@wordpress/use-recommended-components': 'error',
+			'@wordpress/use-recommended-components': 'warn',
 
 			// React best practices
 			'react/jsx-boolean-value': 'error',


### PR DESCRIPTION
## What
Update the eslint config rules for `@wordpress/use-recommended-components` so they `warn` instead of `error`.

## Why

`@wordpress/ui` isn't version stable and they're graduating new components every release. We want to make sure to build new components using the recommended components, but we shouldn't break CI.

---
*PR created automatically by Jules for task [2857431342261436016](https://jules.google.com/task/2857431342261436016) started by @justlevine*

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22OneSearch%20Demo%22%2C%22description%22%3A%22Cross-site%2C%20brand-aware%20search%20across%20a%20multi-brand%20WordPress%20network%2C%20powered%20by%20Algolia.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22search%22%2C%22multisite%22%2C%22algolia%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fonesearch%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-223-39a93cda9ffc78a81c981061a33d0377e6e0b610.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->