### PR TITLE
fix(deps): security bumps for 2 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17769,9 +17769,9 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+			"integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -29811,9 +29811,9 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",
@@ -30208,9 +30208,9 @@
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-			"integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+			"version": "5.2.5",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
+			"integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## Summary
Lockfile-only security bumps for transitive dependencies. No source or manifest changes, no major-version bumps.

| Package | Old → New | Alert # | Severity | GHSA / CVE | Status |
|---|---|---|---|---|---|
| http-proxy-middleware | 2.0.9 → 2.0.10 | #94 | Medium | GHSA-64mm-vxmg-q3vj / CVE-2026-55602 | Fixed |
| webpack-dev-server | 5.2.4 → 5.2.5 | #92 | Medium | GHSA-mx8g-39q3-5c79 / CVE-2026-9595 | Fixed |

No CRITICAL alerts in this set.

## Why
http-proxy-middleware (patch 2.0.10) and webpack-dev-server (patch 5.2.5) stay within the same major as installed and resolve cleanly via `npm update --package-lock-only`. (uuid root incidentally moved 14.0.0 → 14.0.1, both already above the vulnerable range.)

## How tested
Lockfile-only. NOT built or tested locally (disk-discipline constraint). `package-lock.json` validated as parseable JSON. Rely on CI to confirm.

## Residual risk / not-applicable (could NOT be safely fixed)
All remaining alerted packages are transitive copies pinned by parents such that the patched version would require a MAJOR bump of the parent (out of scope), or have no patch:

- **#90 @babel/core (low)** — root copy is already 7.29.7 (patched). Two nested copies remain at 7.25.7, pinned exactly by `@wordpress/babel-preset-default@7.25.7` and `@wordpress/scripts@7.25.7`. Bumping requires a major @wordpress/* upgrade. FLAGGED.
- **#74 uuid (medium)** — root copy already 14.x (patched). Nested copies uuid@9.0.1 (`@wordpress/components` requires `^9.0.1`) and uuid@8.3.2 (`sockjs` requires `^8.3.2`) remain; patch 11.1.1 is a MAJOR bump outside both parent ranges. FLAGGED.
- **#87 markdown-it (medium)** — installed 12.3.2, pinned exactly by `markdownlint@12.3.2`. Patch 14.2.0 is a MAJOR bump (12 → 14). FLAGGED.
- **#64 showdown (medium)** — installed 1.9.1; advisory GHSA-rmmh-p597-ppvv has **no fixed version available** (first_patched_version = null). NOT-APPLICABLE.

These require either upstream @wordpress/* major upgrades or maintainer fixes; left for a dedicated follow-up. Do not merge without CI review.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22OneSearch%20Demo%22%2C%22description%22%3A%22Cross-site%2C%20brand-aware%20search%20across%20a%20multi-brand%20WordPress%20network%2C%20powered%20by%20Algolia.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22search%22%2C%22multisite%22%2C%22algolia%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fonesearch%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-261-ad89a05475f37f20cec6b21a1cd65f615518ae08.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->