### PR TITLE
chore: added release-please version bump markers

### DIFF
--- a/onesearch.php
+++ b/onesearch.php
@@ -43,7 +43,7 @@ function constants(): void {
 	/**
 	 * Version of the plugin.
 	 */
-	define( 'ONESEARCH_VERSION', '1.0.1' ); // x-release-please-version
+	define( 'ONESEARCH_VERSION', '1.0.1' ); // x-release-please-version.
 
 	/**
 	 * Root path to the plugin directory.

--- a/onesearch.php
+++ b/onesearch.php
@@ -16,7 +16,9 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       onesearch
  * Domain Path:       /languages
+ * x-release-please-start-version
  * Version:           1.0.1
+ * x-release-please-end
  * Requires PHP:      8.2
  * Requires at least: 6.8
  * Tested up to:      6.9
@@ -41,7 +43,7 @@ function constants(): void {
 	/**
 	 * Version of the plugin.
 	 */
-	define( 'ONESEARCH_VERSION', '1.0.1' );
+	define( 'ONESEARCH_VERSION', '1.0.1' ); // x-release-please-version
 
 	/**
 	 * Root path to the plugin directory.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,9 @@ Donate link: https://rtcamp.com/
 Tags: OnePress, OneSearch, Cross-site search, Multi-brand network, WordPress multisite, Federated search, Algolia
 Requires at least: 6.8
 Tested up to: 6.9
+<!-- x-release-please-start-version -->
 Stable tag: 1.0.1
+<!-- x-release-please-end -->
 Requires PHP: 8.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,17 @@
 			"release-type": "php",
 			"changelog-path": "CHANGELOG.md",
 			"include-v-in-tag": true,
-			"bump-minor-pre-major": true
+			"bump-minor-pre-major": true,
+			"extra-files": [
+				{
+					"type": "generic",
+					"path": "onesearch.php"
+				},
+				{
+					"type": "generic",
+					"path": "readme.txt"
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `x-release-please-version`/block markers to `onesearch.php` (plugin header + `ONESEARCH_VERSION` constant) and `readme.txt` (`Stable tag`)
- Wire both files into `release-please-config.json` as `extra-files` so release-please keeps their version strings in sync with the manifest/CHANGELOG on every release, instead of only bumping those two centrally

No version bump in this PR — all three stay at `1.0.1`, this just adds the sync mechanism for future releases.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22OneSearch%20Demo%22%2C%22description%22%3A%22Cross-site%2C%20brand-aware%20search%20across%20a%20multi-brand%20WordPress%20network%2C%20powered%20by%20Algolia.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22search%22%2C%22multisite%22%2C%22algolia%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fonesearch%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-273-31cffba02c3944c7050bc1730938efd21ab93ce9.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->