### PR TITLE
chore: Run Copilot code review on GitHub-hosted runners

### DIFF
--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -1,0 +1,22 @@
+name: Copilot code review setup steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+
+jobs:
+  # The job must be named `copilot-setup-steps`, or Copilot ignores this file.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Start Review
+        run: echo "Starting Review."


### PR DESCRIPTION
This repository is public, so Copilot code review cannot use rtCamp self-hosted Actions Runner Controller scale sets, which are not exposed to public repositories.

Adds `.github/workflows/copilot-code-review.yml`, which pins Copilot code review to `ubuntu-latest`. The file takes precedence over `copilot-setup-steps.yml` and over the organization-level runner type for Copilot code review only; Copilot cloud agent keeps using the organization configuration.

No dependencies are installed: Copilot clones the repository and provisions what it needs itself. Repository-specific setup steps can be added to this file later if a review needs extra tooling.

Docs: https://docs.github.com/en/copilot/how-tos/copilot-on-github/set-up-copilot/configure-runners

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22OneSearch%20Demo%22%2C%22description%22%3A%22Cross-site%2C%20brand-aware%20search%20across%20a%20multi-brand%20WordPress%20network%2C%20powered%20by%20Algolia.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22search%22%2C%22multisite%22%2C%22algolia%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fonesearch%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-292-ddb7a645c6e4e973a5efbc56104ec282a6d34ed0.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->